### PR TITLE
Updated to use local command for Friendly Name

### DIFF
--- a/ModelCheckCA.sh
+++ b/ModelCheckCA.sh
@@ -20,7 +20,10 @@ else
 fi
 
 ## Get the full model name from Apple's support page, using the portion of the Serial Number
-fullModelName=$(curl -s "https://support-sp.apple.com/sp/product?cc=${Serial}" | xmllint --format - 2>/dev/null | awk -F'>|<' '/<configCode>/{print $3}')
+# fullModelName=$(curl -s "https://support-sp.apple.com/sp/product?cc=${Serial}" | xmllint --format - 2>/dev/null | awk -F'>|<' '/<configCode>/{print $3}')
+
+## Replacing call to support-sp.apple.com because randomized serial numbers are in use and the site seams to no longer work
+fullModelName=/usr/libexec/PlistBuddy -c "print 0:product-description" /dev/stdin <<< $(/usr/sbin/ioreg -abr -k "product-name")
 
 ## If we didn't get an empty response, echo the full model name
 if [ "$fullModelName" != "" ]; then

--- a/kernelPanicCA.sh
+++ b/kernelPanicCA.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 #
-# Custom command attribute check for kernel panics which occurred in the last seven days.
+# Custom command attribute check for kernel panics which occurred in the last forteen days.
 # Displays the number of occurences.
 #
 #
 
-PanicLogCount=$(/usr/bin/find /Library/Logs/DiagnosticReports -Btime -7 -name *.panic | grep . -c)
+PanicLogCount=$(/usr/bin/find /Library/Logs/DiagnosticReports -Btime -14 -name *.panic | grep . -c)
 
 /bin/echo "$PanicLogCount"


### PR DESCRIPTION
@acodega Thank you for sharing your collection!

I may be still a bit of a novice managing Macs, but this seemed to be a good change idea based on new models having random serial numbers now so that `https://support-sp.apple.com/sp/product?cc=$lastFourOfSerial` throws `<error>0009</error>`